### PR TITLE
Fixed overlay settings data structure error

### DIFF
--- a/Source/VUIE/Overlays/OverlayModule.cs
+++ b/Source/VUIE/Overlays/OverlayModule.cs
@@ -61,7 +61,7 @@ namespace VUIE
             if (LongEventHandler.currentEvent != null)
                 LongEventHandler.ExecuteWhenFinished(() => UIDefOf.VUIE_Overlays.buttonVisible = MoveOverlays);
             else UIDefOf.VUIE_Overlays.buttonVisible = MoveOverlays;
-            if (Scribe.mode == LoadSaveMode.LoadingVars && !Scribe.EnterNode("overlays"))
+            if (!Scribe.EnterNode("overlays") && Scribe.mode == LoadSaveMode.LoadingVars)
                 foreach (var def in DefDatabase<OverlayDef>.AllDefs)
                 {
                     Scribe.EnterNode("overlayWorker_" + def.defName);


### PR DESCRIPTION
Short-circuiting in conditional logic was preventing overlays parent node from being checked consistently. Re-arranged order to ensure this is consistent in all cases. Fixes error on settings page close.