### PR TITLE
Fix for "Tried to get a resource <...> from a different thread" error

### DIFF
--- a/Source/VUIE/Architect/ArchitectModule.cs
+++ b/Source/VUIE/Architect/ArchitectModule.cs
@@ -266,7 +266,7 @@ namespace VUIE
         public static void FixDesPanels(MainTabWindow_Architect __instance)
         {
             var me = UIMod.GetModule<ArchitectModule>();
-            if (me.ActiveIndex != me.VanillaIndex) ArchitectLoadSaver.RestoreState(me.SavedStates[me.ActiveIndex], __instance);
+            if (me.ActiveIndex != me.VanillaIndex) LongEventHandler.ExecuteWhenFinished(() => ArchitectLoadSaver.RestoreState(me.SavedStates[me.ActiveIndex], __instance));
         }
 
         public static void OverrideMouseOverGizmo(ref Gizmo mouseoverGizmo)


### PR DESCRIPTION
Improved FixDesPanels compatibility with mods that may invoke this from the wrong thread.

Spotted this issue when testing with my full mod list.