### PR TITLE
Small improvements to architect state import and removal

### DIFF
--- a/Source/VUIE/Architect/ArchitectExportImport.cs
+++ b/Source/VUIE/Architect/ArchitectExportImport.cs
@@ -42,6 +42,7 @@ namespace VUIE
                     ScribeMetaHeaderUtility.LoadGameDataHeader(ScribeMetaHeaderUtility.ScribeHeaderMode.None, true);
                     Scribe_Deep.Look(ref saved, "ArchitectTab");
                     Scribe.loader.FinalizeLoading();
+                    saved.Vanilla = false;
                     return true;
                 }
                 catch

--- a/Source/VUIE/Architect/ArchitectModule.cs
+++ b/Source/VUIE/Architect/ArchitectModule.cs
@@ -149,7 +149,7 @@ namespace VUIE
                 row.Gap(3f);
                 if (row.ButtonText("VUIE.Remove".Translate()))
                 {
-                    if (state.Vanilla) Messages.Message("VUIE.Architect.Disabled.RemoveVanilla".Translate(), MessageTypeDefOf.RejectInput);
+                    if (state.Vanilla && SavedStates.IndexOf(state) == VanillaIndex) Messages.Message("VUIE.Architect.Disabled.RemoveVanilla".Translate(), MessageTypeDefOf.RejectInput);
                     else
                     {
                         SavedStates.Remove(state);
@@ -165,7 +165,7 @@ namespace VUIE
             var butRect = listing.GetRect(30f);
             if (Widgets.ButtonText(butRect.LeftHalf(), "VUIE.Architect.AddConfig".Translate()))
                 Dialog_TextEntry.GetString(str => AddState(ArchitectLoadSaver.SaveState(str)));
-            if (Widgets.ButtonText(butRect.RightHalf(), "VUIE.Import".Translate())) Find.WindowStack.Add(new Dialog_ArchitectList_Import(state => SavedStates.Add(state)));
+            if (Widgets.ButtonText(butRect.RightHalf(), "VUIE.Import".Translate())) Find.WindowStack.Add(new Dialog_ArchitectList_Import(state => AddState(state)));
 
             listing.End();
         }


### PR DESCRIPTION
* Added an override to the architect state import to prevent these from ever being seen as vanilla.
* Added another condition to the removal button to allow removing "fake" vanilla states.
* Rerouted the architect state import through AddState() so that it benefits from the name-collision check.

lmk if I assumed wrong on the use cases... these changes were to try and address this concern from the comments:
>Toby.Tcg 13 hours ago 
>I'm not sure if this is an issue per se, but you can export the vanilla config, and then import the vanilla config. As a result you have 2 copies of the vanilla config that cannot be edited or removed. I'm not entirely sure as to why you can export the vanilla config when it's impossible to edit or delete the vanilla config in the first place

