### PR TITLE
Fix WindowLayer for custom FloatMenus

### DIFF
--- a/Source/VUIE/FloatMenus/Dialog_FloatMenuGrid.cs
+++ b/Source/VUIE/FloatMenus/Dialog_FloatMenuGrid.cs
@@ -16,6 +16,7 @@ namespace VUIE
 
         public Dialog_FloatMenuGrid(IEnumerable<FloatMenuOption> opts)
         {
+            layer = WindowLayer.Super;
             doCloseX = true;
             doCloseButton = false;
             closeOnClickedOutside = true;

--- a/Source/VUIE/FloatMenus/Dialog_FloatMenuOptions.cs
+++ b/Source/VUIE/FloatMenus/Dialog_FloatMenuOptions.cs
@@ -19,6 +19,7 @@ namespace VUIE
         public Dialog_FloatMenuOptions(IEnumerable<FloatMenuOption> opts)
         {
             options = opts.ToList();
+            layer = WindowLayer.Super;
             doCloseX = true;
             doCloseButton = false;
             closeOnClickedOutside = true;


### PR DESCRIPTION
This sets the WindowLayer for all custom FloatMenus
to match Vanilla.  Fixes a bug with Character Editor (and
any other mod) that places dialogs at a higher-than-normal
layer.

Fixes #9 and is tested locally.