### PR TITLE
Compatibility support for Float Sub-Menus mod.

### DIFF
--- a/Source/VUIE/FloatMenus/FloatMenuModule.cs
+++ b/Source/VUIE/FloatMenus/FloatMenuModule.cs
@@ -71,7 +71,7 @@ namespace VUIE
                 var res = Instance.FloatMenuSettings[key];
                 if (!res.HasValue && menu.options.Count > 30 || res.HasValue && res.Value)
                 {
-                    if (Instance.UseGrid && menu.options.Where(opt => opt.labelInt != "VUIE.FloatMenus.SwitchToFull".Translate()).All(opt => opt.shownItem is not null))
+                    if (Instance.UseGrid && menu.options.Where(opt => opt.labelInt != "VUIE.FloatMenus.SwitchToFull".Translate()).All(opt => opt.shownItem is not null && !ModCompatModule.IsSubMenuOption(opt)))
                         __instance.Add(new Dialog_FloatMenuGrid(menu.options.Where(opt => opt.labelInt != "VUIE.FloatMenus.SwitchToFull".Translate()), key));
                     else
                         __instance.Add(new Dialog_FloatMenuOptions(menu.options.Where(opt => opt.labelInt != "VUIE.FloatMenus.SwitchToFull".Translate()), key));
@@ -82,10 +82,10 @@ namespace VUIE
             return true;
         }
 
-        public static void AddSwitchOption(List<FloatMenuOption> options)
+        public static void AddSwitchOption(FloatMenu __instance, List<FloatMenuOption> options)
         {
             var key = GetKey();
-            if (Instance.ShowSwitchButtons &&
+            if (Instance.ShowSwitchButtons && !ModCompatModule.IsSubMenu(__instance) &&
                 !(Instance.FloatMenuSettings.ContainsKey(key) && Instance.FloatMenuSettings[key].HasValue && Instance.FloatMenuSettings[key].Value) &&
                 key.MethodName != "TryMakeFloatMenu")
                 options.Add(new FloatMenuOption("VUIE.FloatMenus.SwitchToFull".Translate(), () => Instance.FloatMenuSettings[key] = true));


### PR DESCRIPTION
I have a mod that adds support for having sub-menus in float menus: [Float Sub-Menus](https://steamcommunity.com/sharedfiles/filedetails/?id=2864015430). (I commented on VUIE on steam about this a while ago).
This PR adds integration of such sub-menus into VUIE's float menu dialog.

Some notes:
- I only added support in the normal dialog, as I could not see a good way to fit it into the grid view. Thus the check that decides between them now also looks for sub-menus.
- There is no direct dependency on my mod - the interaction uses reflection, but abstracted away in helper methods.
- I tried to make it as non-invasive as possible, but had to change a few things in the dialog.
- The only change that should affect normal menus is that I bumped the left margin of the dialog up 12 units, to be able to fit a sub-menu indicator. If you don't like that change, I can try to rework how the indicators are added.
- The search behavior could be done several ways. The current one is that if the title of the sub-menu is matched, that entire sub-menu is included.
- All sub-menus are currently initially expanded. This seemed to me like the way that fits best into the spirit of the menu dialog, but it could be done either way.

I'm happy to make adjustments if there is anything that does not fit into the rest of the code base.

As my mod has 1.3 support, it would be very nice if this made it into the 1.3 version of VUIE as well. :)